### PR TITLE
Adding missing dependency for core package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "core-js": "^3.0.1",
+    "log4javascript": "^1.4.15",
     "tslib": "^1.9.3"
-  },
-  "devDependencies": {}
+  }
 }


### PR DESCRIPTION
After npm installing @rangy/highlight, I was running into the following error:

```
ERROR in ./node_modules/log4javascript/log4javascript.js
Module build failed: Error: ENOENT: no such file or directory, open 'C:\Users\aksha\Documents\tbd2\node_modules\log4javascript\log4javascript.js'
 @ ./node_modules/@rangy/classapplier/lib/esm5/index.js 18:0-49 20:10-34
 @ ./src/components/Content/Sidebar/index.tsx
 @ ./src/components/Content/index.tsx
 @ ./src/app/content.tsx
```

Although `log4javascript` is listed as a devDependency in the rangy2 package, it is not listed as a dependency in the @rangy/core package and is therefore throwing the above error.

This PR adds the dependency and resolves the issue. An alternate solution would be to remove use of the logger within the core package.